### PR TITLE
assume `sap.` namespace on control types if they don't start with `sap.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ this selector engine uses css selector-like syntax. the main difference is that 
 
 | feature             | examples                                                | suported | notes                                                                                             |
 | ------------------- | ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| type selectors      | `sap.m.Button`, `*`                                     | ✔        |
+| type selectors      | `sap.m.Button`, `m.Button`, `*`                         | ✔        |
 | class selectors     | n/a                                                     | n/a      | as mentioned above, `.` is treated as part of the control type                                    |
 | attribute selectors | `[text]`, `[text='foo']`,`[text*='foo']`                | ✔        | some equality mods are useless for ui5 (eg. `\|=`) but are supported for the sake of completeness |
 | id selectors        | `sap.m.Button#foo`                                      | ✔        | you should not use id selectors if the id is generated (eg. `__button1`) as they can change often |

--- a/src/browser/main.ts
+++ b/src/browser/main.ts
@@ -14,8 +14,13 @@ const queryAll = (_root: Element | Document, selector: string): Element[] => {
     }
     const { rule } = parsedSelector
 
-    // hack to prevent parser from treating . as classes:
     if (rule.tagName && rule.classNames) {
+        // support omitting the sap., since every ui5 control starts with sap (i think):
+        const sapNamespace = 'sap'
+        if (rule.tagName !== sapNamespace) {
+            rule.tagName = `${sapNamespace}.${rule.tagName}`
+        }
+        // hack to prevent parser from treating . as classes:
         rule.tagName = [rule.tagName, ...rule.classNames].join('.')
         delete rule.classNames
     }

--- a/tests/spec.ts
+++ b/tests/spec.ts
@@ -18,6 +18,11 @@ test.describe('any control', () => {
     test('property', ({ page }) => expect(page.locator('ui5=[text]')).toHaveCount(25))
 })
 
+test.describe('implicit "sap." namespace', () => {
+    test('exists', ({ page }) => expect(page.locator('ui5=m.Button')).toHaveCount(12))
+    test("doesn't exist", ({ page }) => expect(page.locator('ui5=m.Table')).toBeHidden())
+})
+
 test.describe('control without property', () => {
     test('exists', ({ page }) => expect(page.locator('ui5=sap.m.Button')).toHaveCount(12))
     test("doesn't exist", ({ page }) => expect(page.locator('ui5=sap.m.Table')).toBeHidden())


### PR DESCRIPTION
fixes #6 