### PR TITLE
make `~=` trim trailing and leading whitespace instead of matching whitespace-separated class names

### DIFF
--- a/.github/workflows/test and publish.yaml
+++ b/.github/workflows/test and publish.yaml
@@ -11,12 +11,20 @@ jobs:
                   node-version: 16.9.1
             - run: npm run setup
             - run: npm run check
-            - uses: actions/upload-artifact@v2
+            - name: upload compiled code
+              uses: actions/upload-artifact@v3
               with:
                   name: build
                   path: dist
               env:
                   CI: true
+            - name: upload playwright report
+              uses: actions/upload-artifact@v3
+              if: always()
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 30
     publish:
         name: publish
         runs-on: ubuntu-latest
@@ -31,7 +39,7 @@ jobs:
             - if: github.ref == 'refs/heads/master'
               run: echo ::set-output name=VERSION_INFO::$(npm view $(node -p "require(\"./package.json\").name")@=${{ steps.current-version.outputs.CURRENT_VERSION }})
               id: version-was-changed
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v3
               # need to publish if the branch isn't master, or it is master and the version in package.json hasn't been published yet
               if: github.ref != 'refs/heads/master' || steps.version-was-changed.outputs.VERSION_INFO == ''
               with:

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ test('ui5 example', ({ page }) => {
 
 this selector engine uses css selector-like syntax. the main difference is that `.` is not used for class names, rather they are treated as part of the type name (ie. `sap.m.Button`)
 
-| feature             | examples                                                | suported | notes                                                                                                                                     |
-| ------------------- | ------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| type selectors      | `sap.m.Button`, `m.Button`, `*`                         | ✔        |
-| class selectors     | n/a                                                     | n/a      | as mentioned above, `.` is treated as part of the control type                                                                            |
-| attribute selectors | `[text]`, `[text='foo']`,`[text*='foo']`                | ✔        | some equality mods are useless for ui5 (eg. `\|=`) but are supported for the sake of completeness                                         |
-| id selectors        | `sap.m.Button#foo`                                      | ✔        | you should not use id selectors if the id is generated (eg. `__button1`) as they can change often                                         |
-| nesting             | `sap.m.Table sap.m.Button`,`sap.m.Table > sap.m.Button` | ❌       | use playwright selector nesting instead (`ui5=sap.m.Table >> ui5=sap.m.Button`)                                                           |
-| pseudo-classes      | `sap.m.Table:has(sap.m.Button)`                         | ✔        | only `:has` is supported for now                                                                                                          |
-| pseudo-elements     | `sap.m.DateTimeField::subclass`                         | ✔        | `::subclass` will match the specified control type and any subtypes (eg. both `sap.m.DateTimeField` and subtypes like `sap.m.DatePicker`) |
-| selector lists      | `sap.m.Button,sap.m.Table`                              | ✔        |
+| feature             | examples                                                   | suported | notes                                                                                                                                         |
+| ------------------- | ---------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| type selectors      | `sap.m.Button`, `m.Button`, `*`                            | ✔        |
+| class selectors     | n/a                                                        | n/a      | as mentioned above, `.` is treated as part of the control type                                                                                |
+| attribute selectors | `[text]`, `[text='foo']`, `[text*='foo']` ,`[text~='foo']` | ✔        | `~=` trims leading and trailing whitespace for the whole value instead of matching a whitespace-separated list of values like it does in CSS. |
+| id selectors        | `sap.m.Button#foo`                                         | ✔        | you should not use id selectors if the id is generated (eg. `__button1`) as they can change often                                             |
+| nesting             | `sap.m.Table sap.m.Button`,`sap.m.Table > sap.m.Button`    | ❌       | use playwright selector nesting instead (`ui5=sap.m.Table >> ui5=sap.m.Button`)                                                               |
+| pseudo-classes      | `sap.m.Table:has(sap.m.Button)`                            | ✔        | only `:has` is supported for now                                                                                                              |
+| pseudo-elements     | `sap.m.DateTimeField::subclass`                            | ✔        | `::subclass` will match the specified control type and any subtypes (eg. both `sap.m.DateTimeField` and subtypes like `sap.m.DatePicker`)     |
+| selector lists      | `sap.m.Button,sap.m.Table`                                 | ✔        |

--- a/src/browser/main.ts
+++ b/src/browser/main.ts
@@ -88,7 +88,7 @@ const querySelector = (root: Element | Document, selector: AstSelector): Element
                     '^=': actualValue.startsWith(expectedValue),
                     '$=': actualValue.endsWith(expectedValue),
                     '*=': actualValue.includes(expectedValue),
-                    '~=': actualValue.split(/\s+/u).includes(expectedValue),
+                    '~=': actualValue.trim() === expectedValue,
                     '|=': actualValue.split('-')[0] === expectedValue,
                 }[
                     throwIfUndefined(

--- a/tests/spec.ts
+++ b/tests/spec.ts
@@ -124,7 +124,7 @@ test('~', async ({ page }) => {
     await navigateToControlSample(page, 'sap.m', 'sap.m.sample.InputAssisted')
     const control = page.locator('ui5=sap.m.Input')
     const element = control.locator('input')
-    await element.fill('asdf ')
+    await element.press('asdf ')
     await element.blur()
     await expect(control.and(page.locator("ui5=[value~='asdf']"))).toBeVisible()
 })

--- a/tests/spec.ts
+++ b/tests/spec.ts
@@ -122,10 +122,14 @@ test.describe('ui5 site - button', () => {
 
 test('~', async ({ page }) => {
     await navigateToControlSample(page, 'sap.m', 'sap.m.sample.InputAssisted')
-    const control = page.locator('ui5=sap.m.Input')
-    const element = control.locator('input')
-    await element.press('asdf ')
-    await element.blur()
+    // on webkit clicking it brings up a popup with a second input box
+    const control = page.locator('ui5=sap.m.Input').last()
+    // need to click and use keyboard because on webkit the input field is readonly
+    await control.click()
+    // focus the second one
+    await control.click()
+    await page.keyboard.type('asdf ')
+    await control.press('Enter')
     await expect(control.and(page.locator("ui5=[value~='asdf']"))).toBeVisible()
 })
 


### PR DESCRIPTION
fixes #24 