### PR TITLE
add back fake root element and evaluate all locators on their root node but with the entire document available so that `ui5_xpath=./following-sibling::*` etc. will work in the context of a parent locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ in this case, `//sap.m.Button[@id='foo']` will work, but `//sap.m.Button[@text='
 
 the XML view matches the control tree from the [ui5 diagnostics window](https://sapui5.hana.ondemand.com/sdk/#/topic/04b75eae78ef4bae9b40cd7540ae8bdc) and the [ui5 inspector chrome extension](https://chromewebstore.google.com/detail/ui5-inspector/bebecogbafbighhaildooiibipcnbngo), so we recommend using one of these when working with the ui5 xpath selector engine.
 
+#### the root node
+
+since the ui5 control tree can have multiple root nodes, the xpath selector engine wraps `sap-ui-area` nodes inside a `root` node:
+
+```xml
+<root>
+    <sap-ui-area id="sap-ui-static">
+        <sap.m.Page id="__page0">
+            <sap.m.Button id="foo"></sap.m.Button>
+        </sap.m.Page>
+    </sap-ui-area>
+    <sap-ui-area id="canvas">
+</root>
+```
+
 #### API
 
 the following xpath functions are available in the `ui5:` namespace:

--- a/tests/xpath.spec.ts
+++ b/tests/xpath.spec.ts
@@ -60,11 +60,17 @@ test.describe('ui5 site', () => {
             )
         })
         test('root element', async ({ page }) => {
-            await expect(page.locator('ui5_xpath=/*')).toHaveCount(1)
-            await expect(page.locator('ui5_xpath=/*/*')).toHaveCount(2) // sanity check
+            await expect(page.locator('ui5_xpath=/root')).toHaveCount(0) // doesn't match anything because it's not a real ui5 element
+            await expect(page.locator('ui5_xpath=/root/*')).toHaveCount(1)
         })
-        test('concatenated with other locator', ({ page }) =>
-            expect(page.locator('#__toolbar2').locator('ui5_xpath=./*')).toHaveCount(4))
+        test.describe('concatenated with other locators', () => {
+            test('child', ({ page }) =>
+                expect(page.locator('#__toolbar2').locator('ui5_xpath=./*')).toHaveCount(4))
+            test('following-sibling', ({ page }) =>
+                expect(
+                    page.locator('#__toolbar0').locator('ui5_xpath=./following-sibling::*').first(),
+                ).toHaveAttribute('id', '__toolbar1'))
+        })
     })
     test.describe('demo apps', () => {
         test('multiple root nodes', async ({ page }) => {


### PR DESCRIPTION
fixes #41 