### PR TITLE
fix playwright >=1.53 hanging issue caused by global fake `module` variable not being deleted after the selector engine is registered

### DIFF
--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -7,10 +7,18 @@ export type SelectorEngine = Parameters<typeof selectors.register>[1]
 const selectorEngine = (fileName: string): SelectorEngine => ({
     // https://github.com/microsoft/playwright/issues/36448
     content: `(() => {
-        if (typeof module === 'undefined') {
+        const useFakeModule = typeof module === 'undefined'
+        if (useFakeModule) {
             window.module = {exports: {}};
         }
-        ${readFileSync(join(__dirname, `../../dist/browser/${fileName}.js`), 'utf8')};
+        try {
+            ${readFileSync(join(__dirname, `../../dist/browser/${fileName}.js`), 'utf8')};
+            return module.exports.default
+        } finally {
+            if (useFakeModule) {
+                delete module
+            }
+        }
         return module.exports.default
     })()`,
 })


### PR DESCRIPTION
this was causing very strange issues on one of the sites at work. it was intermittently hanging after navigating to a page if the next playwright action uses a custom selector engine.

i'm not sure exactly what was going on, but i don't think it's safe to mess with the globals without cleaning it up afterwards anyway